### PR TITLE
Improve Python spawn test using Python Shell instead of child_process

### DIFF
--- a/App/JS/Resources/Python/test.py
+++ b/App/JS/Resources/Python/test.py
@@ -1,4 +1,6 @@
 import sys
 
-print(sys.argv[1])
-sys.stdout.flush()
+infile = sys.stdin.readlines()
+
+print('hi')
+print(infile[0])

--- a/App/JS/main.js
+++ b/App/JS/main.js
@@ -1,8 +1,17 @@
 var shell = require('shelljs');
-const spawn = require('child_process').spawn;
 
-const runTests = spawn('python', ['Resources/Python/test.py', 42]);
+var PythonShell = require('python-shell');
+var pyshell = new PythonShell('App/JS/Resources/Python/test.py');
 
-runTests.stdout.on('data', (data) => {
-  console.log(data)
-})
+pyshell.send('hello');
+
+pyshell.on('message', function (message) {
+  console.log('Message from Python: ' + message);
+});
+
+pyshell.end(function (err,code,signal) {
+  if (err) throw err;
+  console.log('Execution finished.')
+  console.log('The exit code was: ' + code);
+  console.log('The exit signal was: ' + signal);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -3618,6 +3618,11 @@
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
     },
+    "python-shell": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-0.5.0.tgz",
+      "integrity": "sha512-+jgmFZvwk1yMBBDisDlkXXMYv1eEJKbGCtwHLppGIyEV83cKeX9hjOjfR2yONWK3yQFhum0M2r7UE0U//hiK9w=="
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "npm": "^6.2.0",
+    "python-shell": "^0.5.0",
     "shelljs": "^0.8.2"
   }
 }


### PR DESCRIPTION
Added _working_ Python compatability that uses `stdin` and `stdout`